### PR TITLE
Set the correct version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkeep"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["leaty <dev@leaty.net>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Looks like you forgot to update the version number when 0.4.1 was released.