### PR TITLE
use shellexpand to expand environment variables and ~

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ toml = "0.5.8"
 serde = { version = "1.0.125", features = ["derive"] }
 keepass = "0.4.9"
 clipboard = "0.5.0"
+shellexpand = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The configuration may contain multiple sessions, in case you have multiple keepa
 ### Example config
 
 ```toml
-socket = "/tmp/rkeep.sock"
+socket = "~/.rkeep.sock"
 
 [[session]]
 name = "mykeys" # Name of session

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,4 +1,4 @@
-socket = "~/rkeep.sock"
+socket = "~/.rkeep.sock"
 
 [[session]]
 name = "mykeys" # Name of session

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,4 +1,4 @@
-socket = "/tmp/rkeep.sock"
+socket = "~/rkeep.sock"
 
 [[session]]
 name = "mykeys" # Name of session

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,13 @@ use shellexpand::full_with_context_no_errors;
 use std::env;
 use std::path::PathBuf;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 pub struct Config {
     pub socket: PathBuf,
     pub session: Vec<Session>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 pub struct Session {
     pub name: String,
     pub database: PathBuf,
@@ -19,7 +19,7 @@ pub struct Session {
     pub command: Command,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 pub struct Command {
     pub pass: Vec<String>,
     pub list: Vec<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,86 +5,87 @@ use std::path::PathBuf;
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub socket: PathBuf,
-    pub session: Vec<Session>,
+	pub socket: PathBuf,
+	pub session: Vec<Session>,
 }
 
 #[derive(Deserialize, Clone)]
 pub struct Session {
-    pub name: String,
-    pub database: PathBuf,
-    pub keyfile: Option<PathBuf>,
-    pub alive: u32,
-    pub clipboard: u32,
-    pub command: Command,
+	pub name: String,
+	pub database: PathBuf,
+	pub keyfile: Option<PathBuf>,
+	pub alive: u32,
+	pub clipboard: u32,
+	pub command: Command,
 }
 
 #[derive(Deserialize, Clone)]
 pub struct Command {
-    pub pass: Vec<String>,
-    pub list: Vec<String>,
+	pub pass: Vec<String>,
+	pub list: Vec<String>,
 }
 
 impl Config {
-    #[inline(always)]
-    pub fn process(mut self) -> Self {
-        self.socket = expand_path(&self.socket);
-        self.session.iter_mut().for_each(process_session);
+	#[inline(always)]
+	pub fn process(mut self) -> Self {
+		self.socket = expand_path(&self.socket);
+		self.session.iter_mut().for_each(process_session);
 
-        #[inline(always)]
-        #[allow(deprecated)] // suppress `env::home_dir` warning (doesn't matter, since we target linux anyways)
-        fn expand_path(path: &PathBuf) -> PathBuf {
-            PathBuf::from(
-                &(*full_with_context_no_errors(
-                    path.to_str().expect("path contains invalid unicode"),
-                    || {
-                        env::home_dir().map(|path| {
-                            path.to_str()
-                                .expect("path contains invalid unicode")
-                                .to_string()
-                        })
-                    },
-                    |identifier| env::var(identifier).ok(),
-                )),
-            )
-        }
+		#[inline(always)]
+		#[allow(deprecated)] // suppress `env::home_dir` warning (doesn't matter, since we target linux anyways)
+		fn expand_path(path: &PathBuf) -> PathBuf {
+			PathBuf::from(
+				&(*full_with_context_no_errors(
+					path.to_str().expect("path contains invalid unicode"),
+					|| {
+						env::home_dir().map(|path| {
+							path.to_str()
+								.expect("path contains invalid unicode")
+								.to_string()
+						})
+					},
+					|identifier| env::var(identifier).ok(),
+				)),
+			)
+		}
 
-        #[inline(always)]
-        fn process_session(
-            Session {
-                name,
-                ref mut database,
-                ref mut keyfile,
-                ref mut command,
-                ..
-            }: &mut Session,
-        ) {
-            *database = expand_path(&database);
-            keyfile.as_mut().map(|keyfile| expand_path(keyfile));
-            process_command(command, &name);
-        }
+		#[inline(always)]
+		fn process_session(
+			Session {
+				name,
+				ref mut database,
+				ref mut keyfile,
+				ref mut command,
+				..
+			}: &mut Session,
+		) {
+			*database = expand_path(&database);
+			keyfile.as_mut().map(|keyfile| expand_path(keyfile));
+			process_command(command, &name);
+		}
 
-        #[inline(always)]
-        #[allow(deprecated)]
-        fn process_command(cmd: &mut Command, session_name: &str) {
-            cmd.pass
-                .iter_mut()
-                .chain(cmd.list.iter_mut())
-                .for_each(|arg| {
-                    *arg = String::from(full_with_context_no_errors(
-                        &arg.replace("{session.name}", session_name),
-                        || {
-                            env::home_dir().map(|path| {
-                                path.to_str()
-                                    .expect("path contains invalid unicode")
-                                    .to_string()
-                            })
-                        },
-                        |identifier| env::var(identifier).ok(),
-                    ))
-                });
-        }
+		#[inline(always)]
+		#[allow(deprecated)]
+		fn process_command(cmd: &mut Command, session_name: &str) {
+			cmd.pass
+				.iter_mut()
+				.chain(cmd.list.iter_mut())
+				.for_each(|arg| {
+					*arg = String::from(full_with_context_no_errors(
+						&arg.replace("{session.name}", session_name),
+						|| {
+							env::home_dir().map(|path| {
+								path.to_str()
+									.expect("path contains invalid unicode")
+									.to_string()
+							})
+						},
+						|identifier| env::var(identifier).ok(),
+					))
+				});
+		}
 
-        self
-    }
+		self
+	}
 }
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,6 @@ impl Config {
                 });
         }
 
-        dbg!(self)
+        self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,37 +1,90 @@
 use serde::Deserialize;
+use shellexpand::full_with_context_no_errors;
+use std::env;
 use std::path::PathBuf;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct Config {
-	pub socket: PathBuf,
-	pub session: Vec<Session>,
+    pub socket: PathBuf,
+    pub session: Vec<Session>,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct Session {
-	pub name: String,
-	pub database: PathBuf,
-	pub keyfile: Option<PathBuf>,
-	pub alive: u32,
-	pub clipboard: u32,
-	pub command: Command,
+    pub name: String,
+    pub database: PathBuf,
+    pub keyfile: Option<PathBuf>,
+    pub alive: u32,
+    pub clipboard: u32,
+    pub command: Command,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct Command {
-	pub pass: Vec<String>,
-	pub list: Vec<String>,
+    pub pass: Vec<String>,
+    pub list: Vec<String>,
 }
 
-impl Session {
-	/// Parses special values in command, just add more here if needed.
-	/// TODO: Avoid WET
-	pub fn parse(&mut self) {
-		for arg in &mut self.command.pass {
-			*arg = arg.replace("{session.name}", &self.name);
-		}
-		for arg in &mut self.command.list {
-			*arg = arg.replace("{session.name}", &self.name);
-		}
-	}
+impl Config {
+    #[inline(always)]
+    pub fn process(mut self) -> Self {
+        self.socket = expand_path(&self.socket);
+        self.session.iter_mut().for_each(process_session);
+
+        #[inline(always)]
+        #[allow(deprecated)] // suppress `env::home_dir` warning (doesn't matter, since we target linux anyways)
+        fn expand_path(path: &PathBuf) -> PathBuf {
+            PathBuf::from(
+                &(*full_with_context_no_errors(
+                    path.to_str().expect("path contains invalid unicode"),
+                    || {
+                        env::home_dir().map(|path| {
+                            path.to_str()
+                                .expect("path contains invalid unicode")
+                                .to_string()
+                        })
+                    },
+                    |identifier| env::var(identifier).ok(),
+                )),
+            )
+        }
+
+        #[inline(always)]
+        fn process_session(
+            Session {
+                name,
+                ref mut database,
+                ref mut keyfile,
+                ref mut command,
+                ..
+            }: &mut Session,
+        ) {
+            *database = expand_path(&database);
+            keyfile.as_mut().map(|keyfile| expand_path(keyfile));
+            process_command(command, &name);
+        }
+
+        #[inline(always)]
+        #[allow(deprecated)]
+        fn process_command(cmd: &mut Command, session_name: &str) {
+            cmd.pass
+                .iter_mut()
+                .chain(cmd.list.iter_mut())
+                .for_each(|arg| {
+                    *arg = String::from(full_with_context_no_errors(
+                        &arg.replace("{session.name}", session_name),
+                        || {
+                            env::home_dir().map(|path| {
+                                path.to_str()
+                                    .expect("path contains invalid unicode")
+                                    .to_string()
+                            })
+                        },
+                        |identifier| env::var(identifier).ok(),
+                    ))
+                });
+        }
+
+        dbg!(self)
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,108 +21,109 @@ use clap::crate_version;
 pub const VERSION: &'static str = crate_version!();
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Default config path
-    let xdgd = xdg::BaseDirectories::with_prefix("rkeep").unwrap();
-    let xdgc = xdgd.place_config_file("config.toml").unwrap();
-    let default = xdgc.to_str().unwrap();
+	// Default config path
+	let xdgd = xdg::BaseDirectories::with_prefix("rkeep").unwrap();
+	let xdgc = xdgd.place_config_file("config.toml").unwrap();
+	let default = xdgc.to_str().unwrap();
 
-    // Shell args
-    let args = clap_app!(rkeepd =>
-        (version: VERSION)
-        (author: crate_authors!())
-        (about: "Persistent KeePass backend with display hooks")
-        (@arg c: -c --config <FILE> +takes_value default_value(default) "Configuration file")
-    )
-    .get_matches();
+	// Shell args
+	let args = clap_app!(rkeepd =>
+		(version: VERSION)
+		(author: crate_authors!())
+		(about: "Persistent KeePass backend with display hooks")
+		(@arg c: -c --config <FILE> +takes_value default_value(default) "Configuration file")
+	)
+	.get_matches();
 
-    // Load config
-    let config_file = args.value_of("c").unwrap_or(&default);
-    let config_str = fs::read_to_string(&config_file)?;
-    let mut config: Config = toml::from_str::<Config>(&config_str).unwrap().process();
+	// Load config
+	let config_file = args.value_of("c").unwrap_or(&default);
+	let config_str = fs::read_to_string(&config_file)?;
+	let mut config: Config = toml::from_str::<Config>(&config_str).unwrap().process();
 
-    // Set up sessions
-    let sessions = Arc::new(Mutex::new(HashMap::<String, keepass::Session>::new()));
-    for session in &mut config.session {
-        sessions
-            .lock()
-            .unwrap()
-            .insert(session.name.clone(), keepass::Session::new(&session));
-    }
+	// Set up sessions
+	let sessions = Arc::new(Mutex::new(HashMap::<String, keepass::Session>::new()));
+	for session in &mut config.session {
+		sessions
+			.lock()
+			.unwrap()
+			.insert(session.name.clone(), keepass::Session::new(&session));
+	}
 
-    // Set up cleaning thread
-    cleaning(Arc::clone(&sessions));
+	// Set up cleaning thread
+	cleaning(Arc::clone(&sessions));
 
-    // Start listening for clients
-    let _ = fs::remove_file(&config.socket);
-    let listener = UnixListener::bind(config.socket)?;
-    for stream in listener.incoming() {
-        match stream {
-            Ok(stream) => {
-                if let Err(e) = client(&mut sessions.lock().unwrap(), stream) {
-                    println!("{}", e.to_string());
-                }
-            }
-            Err(_) => {
-                continue;
-            }
-        }
-    }
+	// Start listening for clients
+	let _ = fs::remove_file(&config.socket);
+	let listener = UnixListener::bind(config.socket)?;
+	for stream in listener.incoming() {
+		match stream {
+			Ok(stream) => {
+				if let Err(e) = client(&mut sessions.lock().unwrap(), stream) {
+					println!("{}", e.to_string());
+				}
+			}
+			Err(_) => {
+				continue;
+			}
+		}
+	}
 
-    Ok(())
+	Ok(())
 }
 
 fn cleaning(sessions: Arc<Mutex<HashMap<String, keepass::Session>>>) {
-    thread::spawn(move || loop {
-        for (_, session) in sessions.lock().unwrap().iter_mut() {
-            if let Err(e) = session.clean() {
-                println!("{}", e.to_string());
-            }
-        }
+	thread::spawn(move || loop {
+		for (_, session) in sessions.lock().unwrap().iter_mut() {
+			if let Err(e) = session.clean() {
+				println!("{}", e.to_string());
+			}
+		}
 
-        thread::sleep(Duration::new(1, 0));
-    });
+		thread::sleep(Duration::new(1, 0));
+	});
 }
 
 fn client(
-    sessions: &mut HashMap<String, keepass::Session>,
-    stream: UnixStream,
+	sessions: &mut HashMap<String, keepass::Session>,
+	stream: UnixStream,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let stream = BufReader::new(stream);
-    for line in stream.lines() {
-        let command = line.unwrap();
-        let v: Vec<&str> = command.split("|").collect();
-        let (s, c) = (v[0], v[1]);
+	let stream = BufReader::new(stream);
+	for line in stream.lines() {
+		let command = line.unwrap();
+		let v: Vec<&str> = command.split("|").collect();
+		let (s, c) = (v[0], v[1]);
 
-        // Check if session exists by name
-        if sessions.contains_key(s) {
-            let session = &mut sessions.get_mut(s).unwrap();
+		// Check if session exists by name
+		if sessions.contains_key(s) {
+			let session = &mut sessions.get_mut(s).unwrap();
 
-            // Open if not yet open
-            if !session.database.is_some() {
-                session.open(&display::password(&session.command.pass)?)?;
-            }
+			// Open if not yet open
+			if !session.database.is_some() {
+				session.open(&display::password(&session.command.pass)?)?;
+			}
 
-            match c {
-                // Execute keepass backend and display frontend
-                "exec" => {
-                    let list = session.list()?;
-                    let entry = display::list(&session.command.list, &list)?;
-                    session.clip(&entry)?;
+			match c {
+				// Execute keepass backend and display frontend
+				"exec" => {
+					let list = session.list()?;
+					let entry = display::list(&session.command.list, &list)?;
+					session.clip(&entry)?;
 
-                    // Since the user just clipped a new password
-                    // reset clipboard timeouts on other sessions
-                    for (key, other) in sessions {
-                        if key != s {
-                            other.clip_reset();
-                        }
-                    }
+					// Since the user just clipped a new password
+					// reset clipboard timeouts on other sessions
+					for (key, other) in sessions {
+						if key != s {
+							other.clip_reset();
+						}
+					}
 
-                    break;
-                }
-                _ => break,
-            }
-        }
-    }
+					break;
+				}
+				_ => break,
+			}
+		}
+	}
 
-    Ok(())
+	Ok(())
 }
+

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,109 +21,108 @@ use clap::crate_version;
 pub const VERSION: &'static str = crate_version!();
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-	// Default config path
-	let xdgd = xdg::BaseDirectories::with_prefix("rkeep").unwrap();
-	let xdgc = xdgd.place_config_file("config.toml").unwrap();
-	let default = xdgc.to_str().unwrap();
+    // Default config path
+    let xdgd = xdg::BaseDirectories::with_prefix("rkeep").unwrap();
+    let xdgc = xdgd.place_config_file("config.toml").unwrap();
+    let default = xdgc.to_str().unwrap();
 
-	// Shell args
-	let args = clap_app!(rkeepd =>
-		(version: VERSION)
-		(author: crate_authors!())
-		(about: "Persistent KeePass backend with display hooks")
-		(@arg c: -c --config <FILE> +takes_value default_value(default) "Configuration file")
-	)
-	.get_matches();
+    // Shell args
+    let args = clap_app!(rkeepd =>
+        (version: VERSION)
+        (author: crate_authors!())
+        (about: "Persistent KeePass backend with display hooks")
+        (@arg c: -c --config <FILE> +takes_value default_value(default) "Configuration file")
+    )
+    .get_matches();
 
-	// Load config
-	let config_file = args.value_of("c").unwrap_or(&default);
-	let config_str = fs::read_to_string(&config_file)?;
-	let mut config: Config = toml::from_str(&config_str).unwrap();
+    // Load config
+    let config_file = args.value_of("c").unwrap_or(&default);
+    let config_str = fs::read_to_string(dbg!(&config_file))?;
+    let mut config: Config = toml::from_str::<Config>(&config_str).unwrap().process();
 
-	// Set up sessions
-	let sessions = Arc::new(Mutex::new(HashMap::<String, keepass::Session>::new()));
-	for session in &mut config.session {
-		session.parse();
-		sessions
-			.lock()
-			.unwrap()
-			.insert(session.name.clone(), keepass::Session::new(&session));
-	}
+    // Set up sessions
+    let sessions = Arc::new(Mutex::new(HashMap::<String, keepass::Session>::new()));
+    for session in &mut config.session {
+        sessions
+            .lock()
+            .unwrap()
+            .insert(session.name.clone(), keepass::Session::new(&session));
+    }
 
-	// Set up cleaning thread
-	cleaning(Arc::clone(&sessions));
+    // Set up cleaning thread
+    cleaning(Arc::clone(&sessions));
 
-	// Start listening for clients
-	let _ = fs::remove_file(&config.socket);
-	let listener = UnixListener::bind(config.socket)?;
-	for stream in listener.incoming() {
-		match stream {
-			Ok(stream) => {
-				if let Err(e) = client(&mut sessions.lock().unwrap(), stream) {
-					println!("{}", e.to_string());
-				}
-			}
-			Err(_) => {
-				continue;
-			}
-		}
-	}
+    // Start listening for clients
+    let _ = fs::remove_file(&config.socket);
+    let listener = UnixListener::bind(config.socket)?;
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                if let Err(e) = client(&mut sessions.lock().unwrap(), stream) {
+                    println!("{}", e.to_string());
+                }
+            }
+            Err(_) => {
+                continue;
+            }
+        }
+    }
 
-	Ok(())
+    Ok(())
 }
 
 fn cleaning(sessions: Arc<Mutex<HashMap<String, keepass::Session>>>) {
-	thread::spawn(move || loop {
-		for (_, session) in sessions.lock().unwrap().iter_mut() {
-			if let Err(e) = session.clean() {
-				println!("{}", e.to_string());
-			}
-		}
+    thread::spawn(move || loop {
+        for (_, session) in sessions.lock().unwrap().iter_mut() {
+            if let Err(e) = session.clean() {
+                println!("{}", e.to_string());
+            }
+        }
 
-		thread::sleep(Duration::new(1, 0));
-	});
+        thread::sleep(Duration::new(1, 0));
+    });
 }
 
 fn client(
-	sessions: &mut HashMap<String, keepass::Session>,
-	stream: UnixStream,
+    sessions: &mut HashMap<String, keepass::Session>,
+    stream: UnixStream,
 ) -> Result<(), Box<dyn std::error::Error>> {
-	let stream = BufReader::new(stream);
-	for line in stream.lines() {
-		let command = line.unwrap();
-		let v: Vec<&str> = command.split("|").collect();
-		let (s, c) = (v[0], v[1]);
+    let stream = BufReader::new(stream);
+    for line in stream.lines() {
+        let command = line.unwrap();
+        let v: Vec<&str> = command.split("|").collect();
+        let (s, c) = (v[0], v[1]);
 
-		// Check if session exists by name
-		if sessions.contains_key(s) {
-			let session = &mut sessions.get_mut(s).unwrap();
+        // Check if session exists by name
+        if sessions.contains_key(s) {
+            let session = &mut sessions.get_mut(s).unwrap();
 
-			// Open if not yet open
-			if !session.database.is_some() {
-				session.open(&display::password(&session.command.pass)?)?;
-			}
+            // Open if not yet open
+            if !session.database.is_some() {
+                session.open(&display::password(&session.command.pass)?)?;
+            }
 
-			match c {
-				// Execute keepass backend and display frontend
-				"exec" => {
-					let list = session.list()?;
-					let entry = display::list(&session.command.list, &list)?;
-					session.clip(&entry)?;
+            match c {
+                // Execute keepass backend and display frontend
+                "exec" => {
+                    let list = session.list()?;
+                    let entry = display::list(&session.command.list, &list)?;
+                    session.clip(&entry)?;
 
-					// Since the user just clipped a new password
-					// reset clipboard timeouts on other sessions
-					for (key, other) in sessions {
-						if key != s {
-							other.clip_reset();
-						}
-					}
+                    // Since the user just clipped a new password
+                    // reset clipboard timeouts on other sessions
+                    for (key, other) in sessions {
+                        if key != s {
+                            other.clip_reset();
+                        }
+                    }
 
-					break;
-				}
-				_ => break,
-			}
-		}
-	}
+                    break;
+                }
+                _ => break,
+            }
+        }
+    }
 
-	Ok(())
+    Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Load config
     let config_file = args.value_of("c").unwrap_or(&default);
-    let config_str = fs::read_to_string(dbg!(&config_file))?;
+    let config_str = fs::read_to_string(&config_file)?;
     let mut config: Config = toml::from_str::<Config>(&config_str).unwrap().process();
 
     // Set up sessions


### PR DESCRIPTION
fixes #9 and somewhat fixes #10

repository seems a bit inactive, so this Lua script can be used as a workaround while the pr isn't merged (doesn't support tildes)

https://github.com/wfrsk/dotfiles/blob/e99de4d596c42e36deb7a1815b2bc3b261eb5a14/util/translate_environment.lua

run `rkee{p,pd} -c <(cat /path/to/config.toml | /path/to/translate_environment.lua)` to feed rkeep the modified configuration file, examples:

https://github.com/wfrsk/dotfiles/blob/e99de4d596c42e36deb7a1815b2bc3b261eb5a14/config/desktop_env/i3wm#L51
https://github.com/wfrsk/dotfiles/blob/e99de4d596c42e36deb7a1815b2bc3b261eb5a14/config/desktop_env/i3wm#L205
